### PR TITLE
Remove notify.json generation, update dependencies and refactor code

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,28 +31,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      - name: Install poetry
+        run: pipx install poetry
+
       - name: Set up python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Load cached Poetry installation
-        id: cached-poetry
-        uses: actions/cache@v4
-        with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-0  # increment to reset cache
-      - name: Install Poetry
-        if: steps.cached-poetry.outputs.cache-hit != 'true'
-        uses: snok/install-poetry@v1
+          cache: poetry
+
       - name: Install dependencies
         run: poetry install
+
       - name: Build
         run: |
           export MONGO_URL="123123"
           export MONGO_DB="123123"
-          make generate_notify_schema
+          # make generate_notify_schema
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,6 @@ update_locale:  # Extract strings and update .PO file for Russian language
 full_update_locale:  # Compile .PO files to .MO files
 	poetry run -- python -m cli full_update_locale
 
-generate_notify_schema:  # Generate schema for notify.json file
-	poetry run -- python -m cli generate_notify_schema
-
-generate_notify_md:  # Generate markdown for notify.json file
-	poetry run -- python -m cli generate_notify_md
-
 generate_makefile:  # Generate Makefile
 	poetry run -- python -m cli generate_makefile
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Telegram bot for downloading videos from social networks.
 
 ### Constant Path
 
-These constants using for getting path to files. You can see these paths in this document.
+These are constants used for getting a path to files. You can see these paths in this document.
 
 | Name         | Description               | Value                            |
 |--------------|---------------------------|----------------------------------|
@@ -96,7 +96,7 @@ This is .json file like this:
 
 This file will be used in `/help` command.
 
-You can image this like these structure:
+You can image this like these structures:
 
 ```markdown
 Contacts:
@@ -104,141 +104,26 @@ Contacts:
 - {type}: [{text}]({url})
 ```
 
-Any of these fields can be internationalized.
+Any of these fields can be internationalised.
 For this you need to set `_{lang}` suffix in keys.
 For example: `type_ru` or `text_en`.
 By default, using `DEFAULT_LOCALE` env variable or suffix-less key.
 
-## 🔊 Notification service
-
-This service can send notifications about errors and other events to different services.
-
-### Supported services
-
-| Support | Service                               | Code Name       | Description                                 | Events type support         |
-|---------|---------------------------------------|-----------------|---------------------------------------------|-----------------------------|
-| ✅       | [Save to file](#module-file_reporter) | `file_reporter` | Saving data to JSON file                    | `REPORT`                    |
-| ✅       | [Chanify](#module-chanify)            | `chanify`       | [Chanify.net](https://chanify.net)          | [Any](#all-supported-event) |
-| ✅       | [Ntfy](#module-ntfy)                  | `ntfy`          | [ntfy.sh](https://ntyf.sh)                  | [Any](#all-supported-event) |
-| ❌       | Pushsafer                             | `pushsafer`     | [pushsafer.com](https://www.pushsafer.com/) | [Any](#all-supported-event) |
-| ❌       | Email                                 | `email`         | Email notification                          | [Any](#all-supported-event) |
-| ❌       | Gotify                                | `gotify`        | [Gotify.net](https://gotify.net/)           | [Any](#all-supported-event) |
-| ❌       | Pushover                              | `pushover`      | [Pushover.net](https://pushover.net/)       | [Any](#all-supported-event) |
-| ❌       | PushBullet                            | `pushbullet`    | [PushBullet.com](https://pushbullet.com/)   | [Any](#all-supported-event) |
-| ❌       | Telegram                              | `telegram`      | [Telegram.org](https://telegram.org)        | [Any](#all-supported-event) |
-| ❌       | Discord                               | `discord`       | [Discord.com](https://discord.com/)         | [Any](#all-supported-event) |
-
-- ✅ -- Full Supported now
-- ❌ -- Not yet implemented
-
-### All supported events
-
-- [x] `REPORT` -- The user submits an error while parsing from inline
-- [x] `EXCEPTION` -- Bot catch exception on top level
-- [x] `START` -- Bot started
-- [x] `STOP` -- Bot stopped
-- [x] `SHUTDOWN` -- Bot shutdown
-
-### Configurate
-
-Set env `NOTIFY_PATH` with a path to config. Default path is `CONFIG_PATH/notify.json`
-
-Example of `notify.json`:
-
-```json5
-{
-  // This is optional, used for validation in your IDE
-  "$schema": "https://jag-k.github.io/tiktok-downloader/schemas/notify.schema.json",
-  "services": [
-    {
-      "service": "file_reporter"
-    },
-    {
-      "service": "file_reporter",
-      "config": {
-        "file_path": "/path/to/reporter/file.json"
-      }
-    },
-    {
-      "service": "chanify",
-      "types": [
-        "report"
-      ],
-      "config": {
-        "url": "https://api.chanify.net",
-        "token": "123"
-      }
-    },
-    {
-      "service": "chanify",
-      "types": [
-        "exception"
-      ],
-      "config": {
-        "url": "https://api.example.com",
-        "token": "456"
-      }
-    }
-  ]
-}
-```
-
-You can validate your config with [JSON Schema](https://json-schema.org/).
-[Link to schema](https://jag-k.github.io/tiktok-downloader/schemas/notify.schema.json)
-
-<!--region:notify-->
-
-#### Module `chanify`
-
-A wrapper for [Chanify](https://chanify.net) Notifications
-
-Config:
-
-| Name    | Description        | Default value             | Required |
-|---------|--------------------|---------------------------|----------|
-| `token` | Chanify token      |                           | ✅ True   |
-| `url`   | Chanify server url | `https://api.chanify.net` | ❌ False  |
-
-#### Module `file_reporter`
-
-Reporter that writes reports to a file.
-
-Config:
-
-| Name        | Description         | Default value  | Required |
-|-------------|---------------------|----------------|----------|
-| `file_path` | Path to report file | `$REPORT_PATH` | ❌ False  |
-
-#### Module `ntfy`
-
-A wrapper for [Ntfy](https://ntfy.sh) Notifications
-
-Config:
-
-| Name         | Description                       | Default value       | Required |
-|--------------|-----------------------------------|---------------------|----------|
-| `url`        | Ntfy server url                   | `https://ntfy.sh`   | ❌ False  |
-| `topic`      | Ntfy topic                        | `tiktok-downloader` | ❌ False  |
-| `token`      | Ntfy token                        | `None`              | ❌ False  |
-| `token_type` | Ntfy token type (Bearer or Basic) | `Bearer`            | ❌ False  |
-| `send_file`  | Send file with notification       | `False`             | ❌ False  |
-
-<!--endregion:notify-->
-
 ## Development
 
-This project use [Poetry](https://python-poetry.org/) for dependency management.
+This project uses [Poetry](https://python-poetry.org/) for dependency management.
 
 For database project use MongoDB. More about this you can read [here](#database).
 
 ### Install project
 
-Python version: **3.11**
-Poetry version: **1.4.1**
+Python version: **3.12**
+Poetry version: **1.8.2**
 
 ```bash
 poetry install
 pre-commit install
+pre-commit install-hooks
 ```
 
 ### Database
@@ -277,7 +162,7 @@ poetry run python main.py
 
 ### Makefile commands
 
-You can use this for updating I18n files, generate schemas and more.
+You can use this for updating I18n files, generate schemas, and more.
 
 <!--region:makefile-->
 
@@ -286,8 +171,6 @@ make compile_locale  # Extract strings from code to .POT file
 make extract_locale  # Update .PO file for Russian language
 make update_locale  # Extract strings and update .PO file for Russian language
 make full_update_locale  # Compile .PO files to .MO files
-make generate_notify_schema  # Generate schema for notify.json file
-make generate_notify_md  # Generate markdown for notify.json file
 make generate_makefile  # Generate Makefile
 make generate_makefile_md  # Generate Makefile and update README.md
 make full_update_readme  # Full update README.md

--- a/cli/comands.py
+++ b/cli/comands.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections.abc import Callable
 
@@ -83,32 +82,8 @@ def full_update_locale(lang: str = DEFAULT_LOCALE) -> None:
     update_locale(lang)
 
 
-@add_command(description="Generate schema for notify.json file")
-def generate_notify_schema() -> None:
-    from app.utils.notify.generate_schemas import generate_jsonschema
-
-    schemas = BASE_PATH / "public" / "schemas"
-    schemas.mkdir(parents=True, exist_ok=True)
-
-    with open(schemas / "notify.schema.json", "w") as f:
-        json.dump(generate_jsonschema(), f, indent=4, ensure_ascii=False, default=str)
-
-
-@add_command(description="Generate markdown for notify.json file")
-def generate_notify_md() -> None:
-    from app.utils.notify.generate_schemas import generate_markdown
-
-    readme_file = BASE_PATH / "README.md"
-    readme = readme_file.read_text()
-
-    readme = markdown_update_region(readme, "notify", generate_markdown())
-
-    readme_file.write_text(readme.strip() + "\n")
-    print("README.md updated")
-
-
 @add_command(description="Generate Makefile")
-def generate_makefile() -> None:
+def generate_makefile() -> list[dict]:
     makefile = BASE_PATH / "Makefile"
 
     data = [
@@ -122,6 +97,7 @@ def generate_makefile() -> None:
         if (extra := f" {func.__extra__}" if hasattr(func, "__extra__") else "") or True
     ]
 
+    # noinspection PyTypeChecker,PydanticTypeChecker
     cmds = "\n".join(
         f"{name}:{description}\n" f"\tpoetry run -- python -m cli {name}{extra}\n"
         for name, description, extra in map(dict.values, data)
@@ -141,6 +117,7 @@ def generate_makefile() -> None:
 def generate_makefile_md() -> None:
     data = generate_makefile()
     text = "```bash"
+    # noinspection PyTypeChecker,PydanticTypeChecker
     for name, description, extra in map(dict.values, data):
         text += f"\nmake {name}{description}"
     text += "\n```"
@@ -153,5 +130,4 @@ def generate_makefile_md() -> None:
 
 @add_command(description="Full update README.md")
 def full_update_readme() -> None:
-    generate_notify_md()
     generate_makefile_md()

--- a/poetry.lock
+++ b/poetry.lock
@@ -444,13 +444,13 @@ trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.26.0"
+version = "0.27.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
-    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [package.dependencies]
@@ -546,18 +546,18 @@ test = ["flake8 (>=5.0,<6.0)", "mypy (>=1.4,<2.0)", "pycodestyle (>=2.9,<3.0)", 
 
 [[package]]
 name = "mongopersistence"
-version = "0.3.0"
+version = "0.3.1"
 description = "Package to add persistence to your telegram bot using pymongo"
 optional = false
-python-versions = ">=3.10,<4.0"
+python-versions = "<4.0,>=3.10"
 files = [
-    {file = "mongopersistence-0.3.0-py3-none-any.whl", hash = "sha256:c7d075e8b8b980b5ec3ee4a4d8ca0801d9782bcdd221b01d34d4831990a9504f"},
-    {file = "mongopersistence-0.3.0.tar.gz", hash = "sha256:69cb2ca863003d8d119ffbd4dd455e4d5c1238250396774fd69e22e401339e08"},
+    {file = "mongopersistence-0.3.1-py3-none-any.whl", hash = "sha256:1f5a47af657d1a0b00ed4ea47857bdc70709bde1d4873d4534493215f122c192"},
+    {file = "mongopersistence-0.3.1.tar.gz", hash = "sha256:948c6d852f854c44e8e09f3839daaa5ae8bea8d8153486566965f1b22a47c1be"},
 ]
 
 [package.dependencies]
 motor = ">=3.1.2,<4.0.0"
-python-telegram-bot = ">=20.1,<21.0"
+python-telegram-bot = ">=20.1"
 
 [[package]]
 name = "motor"
@@ -912,22 +912,22 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-telegram-bot"
-version = "20.8"
+version = "21.1.1"
 description = "We have made you a wrapper you can't refuse"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "python-telegram-bot-20.8.tar.gz", hash = "sha256:0e1e4a6dbce3f4ba606990d66467a5a2d2018368fe44756fae07410a74e960dc"},
-    {file = "python_telegram_bot-20.8-py3-none-any.whl", hash = "sha256:a98ddf2f237d6584b03a2f8b20553e1b5e02c8d3a1ea8e17fd06cc955af78c14"},
+    {file = "python-telegram-bot-21.1.1.tar.gz", hash = "sha256:5fd21710902270f5946c6a484918227b361b8119e1dadae6b3dd7fcee3b1a74e"},
+    {file = "python_telegram_bot-21.1.1-py3-none-any.whl", hash = "sha256:dded93d733585a37b382fd5e088faffc37c3ae6d2bd4052d105d9a40f8a0152a"},
 ]
 
 [package.dependencies]
-httpx = ">=0.26.0,<0.27.0"
+httpx = ">=0.27,<1.0"
 
 [package.extras]
-all = ["APScheduler (>=3.10.4,<3.11.0)", "aiolimiter (>=1.1.0,<1.2.0)", "cachetools (>=5.3.2,<5.4.0)", "cryptography (>=39.0.1)", "httpx[http2]", "httpx[socks]", "pytz (>=2018.6)", "tornado (>=6.4,<7.0)"]
-callback-data = ["cachetools (>=5.3.2,<5.4.0)"]
-ext = ["APScheduler (>=3.10.4,<3.11.0)", "aiolimiter (>=1.1.0,<1.2.0)", "cachetools (>=5.3.2,<5.4.0)", "pytz (>=2018.6)", "tornado (>=6.4,<7.0)"]
+all = ["APScheduler (>=3.10.4,<3.11.0)", "aiolimiter (>=1.1.0,<1.2.0)", "cachetools (>=5.3.3,<5.4.0)", "cryptography (>=39.0.1)", "httpx[http2]", "httpx[socks]", "pytz (>=2018.6)", "tornado (>=6.4,<7.0)"]
+callback-data = ["cachetools (>=5.3.3,<5.4.0)"]
+ext = ["APScheduler (>=3.10.4,<3.11.0)", "aiolimiter (>=1.1.0,<1.2.0)", "cachetools (>=5.3.3,<5.4.0)", "pytz (>=2018.6)", "tornado (>=6.4,<7.0)"]
 http2 = ["httpx[http2]"]
 job-queue = ["APScheduler (>=3.10.4,<3.11.0)", "pytz (>=2018.6)"]
 passport = ["cryptography (>=39.0.1)"]
@@ -1218,4 +1218,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e8cda174bf557afb1f73651f150bb7d87709a9caf47848a8867b35006ebaebcd"
+content-hash = "4567e8e021c1d16c1b8a1178b958ed8f9238dd0eaa71c512d0a1d9232e9f2f08"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-python-telegram-bot = "^20.1"
+python-telegram-bot = "^21.1.1"
 aiohttp = "^3.8.3"
 pytube = "^15.0.0"
 python-dotenv = "^1.0.0"
@@ -15,7 +15,7 @@ pytz = "^2024.1"
 aiofiles = "^23.1.0"
 pydantic = "^1.10.15"
 motor = "^3.1.2"
-mongopersistence = "^0.3.0"
+mongopersistence = "^0.3.1"
 contextvars = "^2.4"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- The notify.json generation scripts and related commands have been removed from the codebase.
- The poetry.lock file has been updated to reflect changes in the versions of httpx, mongopersistence, and python-telegram-bot dependencies.
- Changes have also been made to update python and poetry versions in the project setup.
- Several updates have been made to the .github/workflows/static.yml, and changes in README.md document reflect the removal of notify.json generation scripts.
- The revised codebase now promotes cleaner and more efficient execution.